### PR TITLE
# Xcode15でビルド時にDT_TOOLCHAIN_DIRエラーになるので対応

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -21,14 +21,40 @@ target 'iOSReferenceRepository' do
 
 end
 
+# post install
 # Xcode14.3からCocoaPodsでインストールしたライブラリのMinimum DevelopmentsがiOS11未満だとビルドエラーになる
 # https://developer.apple.com/forums/thread/728021
 post_install do |installer|
+  # fix xcode 15 DT_TOOLCHAIN_DIR - remove after fix oficially - https://github.com/CocoaPods/CocoaPods/issues/12065
+  installer.aggregate_targets.each do |target|
+      target.xcconfigs.each do |variant, xcconfig|
+      xcconfig_path = target.client_root + target.xcconfig_relative_path(variant)
+      IO.write(xcconfig_path, IO.read(xcconfig_path).gsub("DT_TOOLCHAIN_DIR", "TOOLCHAIN_DIR"))
+      end
+  end
+
   installer.generated_projects.each do |project|
     project.targets.each do |target|
       target.build_configurations.each do |config|
+        if config.base_configuration_reference.is_a? Xcodeproj::Project::Object::PBXFileReference
+            xcconfig_path = config.base_configuration_reference.real_path
+            IO.write(xcconfig_path, IO.read(xcconfig_path).gsub("DT_TOOLCHAIN_DIR", "TOOLCHAIN_DIR"))
+        end
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
       end
    end
   end
 end
+
+# Xcode15のビルドエラー不具合が解消されたら以下に戻す
+## Xcode14.3からCocoaPodsでインストールしたライブラリのMinimum DevelopmentsがiOS11未満だとビルドエラーになる
+## https://developer.apple.com/forums/thread/728021
+#post_install do |installer|
+#  installer.generated_projects.each do |project|
+#    project.targets.each do |target|
+#      target.build_configurations.each do |config|
+#        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+#      end
+#   end
+#  end
+#end


### PR DESCRIPTION
### 概要
<!-- プルリクの概要 -->
Xcode15でビルド時にDT_TOOLCHAIN_DIRエラーになるので対応

### 関連するIssue
#39 

### 実装内容
<!-- 実装内容を箇条書きする -->
- [x] Podfileの修正
- [ ] SwiftLintの実行

### 動作確認した内容
<!-- 確認した動作内容を箇条書きする -->
- [x] ビルド成功
- [ ] 関連する箇所の修正も実施した
