### PR TITLE
SwiftFormatをCocoaPodsでインストール

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,6 +7,8 @@ target 'iOSReferenceRepository' do
 
   # Pods for iOSReferenceRepository
 	pod 'SwiftLint'
+  pod 'SwiftFormat/CLI', '~> 0.49'
+
 	pod 'R.swift'
 	pod 'RxSwift'
 	pod 'RxCocoa'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,12 +8,14 @@ PODS:
   - RxRelay (6.5.0):
     - RxSwift (= 6.5.0)
   - RxSwift (6.5.0)
+  - SwiftFormat/CLI (0.49.9)
   - SwiftLint (0.47.1)
 
 DEPENDENCIES:
   - R.swift
   - RxCocoa
   - RxSwift
+  - SwiftFormat/CLI (~> 0.49)
   - SwiftLint
 
 SPEC REPOS:
@@ -23,6 +25,7 @@ SPEC REPOS:
     - RxCocoa
     - RxRelay
     - RxSwift
+    - SwiftFormat
     - SwiftLint
 
 SPEC CHECKSUMS:
@@ -31,8 +34,9 @@ SPEC CHECKSUMS:
   RxCocoa: 94f817b71c07517321eb4f9ad299112ca8af743b
   RxRelay: 1de1523e604c72b6c68feadedd1af3b1b4d0ecbd
   RxSwift: 5710a9e6b17f3c3d6e40d6e559b9fa1e813b2ef8
+  SwiftFormat: 016c15401d06959ef9f81d7956462e91f55b8ac5
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
 
-PODFILE CHECKSUM: 9117e2038e79e934ec8d10f3cd6d5e690becee65
+PODFILE CHECKSUM: 80d44d570956a5ce302abd70f761725e6d9a78de
 
 COCOAPODS: 1.11.2

--- a/iOSReferenceRepository/AppManager/AppDelegate.swift
+++ b/iOSReferenceRepository/AppManager/AppDelegate.swift
@@ -1,37 +1,28 @@
 //
 //  AppDelegate.swift
-//  
-//  
+//
+//
 //  Created by hisanori on 2022/09/10.
-//  
-
+//
 
 import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    // MARK: UISceneSession Lifecycle
-
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    func application(_: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options _: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+    func application(_: UIApplication, didDiscardSceneSessions _: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
 }
-


### PR DESCRIPTION
## 概要
SwiftFormatの導入のPRです。
SPMで導入した際に`SPMだとNo such module 'Glibc'`でコンパイルエラーになり、原因特定と解決ができませんでした。
そのため、CocoaPods経由でインストールしています。

## 関連するIssue
#72 

## 実装の詳細
- [x] CocoaPods経由でインストール
- [x] AppDelegateにFormat適用

## 動作確認
- [x] ビルド成功

## 備考